### PR TITLE
Add Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+
+## Description
+Describe the changes you made and why.
+
+## Related Issues
+Link to any related issues (e.g., Fixes #123).
+
+## Screenshots
+If applicable, add screenshots here.
+
+## Checklist
+- [ ] I have tested my code
+- [ ] I followed the project coding style
+- [ ] I documented the changes
+- [ ] I updated the changelog


### PR DESCRIPTION
This pull request adds a pull request template to the repository under  ".github/pull_request_template.md".
 
It will help standardize the structure of all future pull requests and improve clarity during code reviews.

